### PR TITLE
fire an event when the midi output device is not selected

### DIFF
--- a/x-webmidioutput.html
+++ b/x-webmidioutput.html
@@ -158,6 +158,7 @@ Polymer({
         var outputs=this.midiAccess.midi.outputs;
         if(Idx=="" || Idx=="false" || Idx===false) {
             this.outputIdx="false";
+            this.fire("midioutput-updated-notselected:"+this.id);
         } else {
             for(key in outputs) {
                 if(key==Idx) {


### PR DESCRIPTION
When I use x-webmidi in my project, I need to switch the output to web audio when the output device is not selected, so this may be helpful. :)
